### PR TITLE
Fix mounted check in vibration support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,8 @@ class _MyHomePageState extends State<MyHomePage> {
     bool? hasCustomVibrationsSupport =
         await Vibration.hasCustomVibrationsSupport();
 
+    if (!mounted) return;
+
     setState(() {
       _hasVibrator = hasVibrator ?? false;
       _hasAmplitudeControl = hasAmplitudeControl ?? false;


### PR DESCRIPTION
## Summary
- prevent calling setState when widget isn't mounted yet in `_checkVibrationSupport`

## Testing
- `flutter analyze` *(fails: flutter not installed)*
- `dart analyze` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684061659b58832d853da336ac5c9cb9